### PR TITLE
Fix sonarqube bugs

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -30,7 +30,7 @@ public class TorpedoStore {
 
   public boolean fire(int numberOfTorpedos){
     if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount){
-      new IllegalArgumentException("numberOfTorpedos");
+      throw new IllegalArgumentException("numberOfTorpedos");
     }
 
     boolean success = false;

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -14,6 +14,8 @@ public class TorpedoStore {
 
   private int torpedoCount = 0;
 
+  private Random generator = new Random();
+
   public TorpedoStore(int numberOfTorpedos){
     this.torpedoCount = numberOfTorpedos;
 
@@ -36,7 +38,6 @@ public class TorpedoStore {
     boolean success = false;
 
     // simulate random overheating of the launcher bay which prevents firing
-    Random generator = new Random();
     double r = generator.nextDouble();
 
     if (r >= FAILURE_RATE) {

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -42,7 +42,7 @@ public class TorpedoStore {
 
     if (r >= FAILURE_RATE) {
       // successful firing
-      this.torpedoCount =- numberOfTorpedos;
+      this.torpedoCount -= numberOfTorpedos;
       success = true;
     } else {
       // simulated failure

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -3,60 +3,60 @@ package hu.bme.mit.spaceship;
 import java.util.Random;
 
 /**
-* Class storing and managing the torpedoes of a ship
-*
-* (Deliberately contains bugs.)
-*/
+ * Class storing and managing the torpedoes of a ship
+ * <p>
+ * (Deliberately contains bugs.)
+ */
 public class TorpedoStore {
 
-  // rate of failing to fire torpedos [0.0, 1.0]
-  private double FAILURE_RATE = 0.0; //NOSONAR
+    // rate of failing to fire torpedos [0.0, 1.0]
+    private double FAILURE_RATE = 0.0; //NOSONAR
 
-  private int torpedoCount = 0;
+    private int torpedoCount = 0;
 
-  private Random generator = new Random();
+    private Random generator = new Random();
 
-  public TorpedoStore(int numberOfTorpedos){
-    this.torpedoCount = numberOfTorpedos;
+    public TorpedoStore(int numberOfTorpedos) {
+        this.torpedoCount = numberOfTorpedos;
 
-    // update failure rate if it was specified in an environment variable
-    String failureEnv = System.getenv("IVT_RATE");
-    if (failureEnv != null){
-      try {
-        FAILURE_RATE = Double.parseDouble(failureEnv);
-      } catch (NumberFormatException nfe) {
-        FAILURE_RATE = 0.0;
-      }
-    }
-  }
-
-  public boolean fire(int numberOfTorpedos){
-    if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount){
-      throw new IllegalArgumentException("numberOfTorpedos");
+        // update failure rate if it was specified in an environment variable
+        String failureEnv = System.getenv("IVT_RATE");
+        if (failureEnv != null) {
+            try {
+                FAILURE_RATE = Double.parseDouble(failureEnv);
+            } catch (NumberFormatException nfe) {
+                FAILURE_RATE = 0.0;
+            }
+        }
     }
 
-    boolean success = false;
+    public boolean fire(int numberOfTorpedos) {
+        if (numberOfTorpedos < 1 || numberOfTorpedos > this.torpedoCount) {
+            throw new IllegalArgumentException("numberOfTorpedos");
+        }
 
-    // simulate random overheating of the launcher bay which prevents firing
-    double r = generator.nextDouble();
+        boolean success = false;
 
-    if (r >= FAILURE_RATE) {
-      // successful firing
-      this.torpedoCount -= numberOfTorpedos;
-      success = true;
-    } else {
-      // simulated failure
-      success = false;
+        // simulate random overheating of the launcher bay which prevents firing
+        double r = generator.nextDouble();
+
+        if (r >= FAILURE_RATE) {
+            // successful firing
+            this.torpedoCount -= numberOfTorpedos;
+            success = true;
+        } else {
+            // simulated failure
+            success = false;
+        }
+
+        return success;
     }
 
-    return success;
-  }
+    public boolean isEmpty() {
+        return this.torpedoCount <= 0;
+    }
 
-  public boolean isEmpty(){
-    return this.torpedoCount <= 0;
-  }
-
-  public int getTorpedoCount() {
-    return this.torpedoCount;
-  }
+    public int getTorpedoCount() {
+        return this.torpedoCount;
+    }
 }


### PR DESCRIPTION
Fixes for the following bugs indicated by sonarqube:
*  Reuse Random for generating random numbers truly
*  Add a throw expression before an exception for actually throwing it 
*  Switch =- to -= that resolves torpedoStore not depleting